### PR TITLE
feat: adds delivery publishing option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/async-events",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "An async event emitter for NodeJS with support for emitting events (not waiting for subscriptions to be satisfied), and publishing events (waiting for subscriptions to be satisfied)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/Topic.js
+++ b/src/Topic.js
@@ -4,7 +4,7 @@ module.exports = {
   factory: (polynBp, polynIm, TopicMemoryRepo, Publisher) => {
     'use strict'
 
-    const { registerBlueprint } = polynBp
+    const { optional, registerBlueprint } = polynBp
     const { immutable } = polynIm
 
     registerBlueprint('TopicRepo', {
@@ -17,18 +17,20 @@ module.exports = {
     const TopicOptions = immutable('TopicOptions', {
       topic: 'string',
       repo: 'TopicRepo?',
+      timeout: optional('number').withDefault(3000),
     })
 
     function Topic (pubsubOptions) {
       const options = new TopicOptions(pubsubOptions)
 
       const repo = options.repo || TopicMemoryRepo(options.topic)
-      const { publish, emit } = Publisher(options.topic, repo)
+      const { publish, emit, deliver } = Publisher(options.topic, repo, options.timeout)
 
       return {
         name: options.topic,
         publish,
         emit,
+        deliver,
         subscribe: repo.subscribe,
         unsubscribe: repo.unsubscribe,
         // below are undocumented and subject to change or deprecation


### PR DESCRIPTION
Adds a 3rd publishing option: delivery. The `deliver` function is
similar to `publish`, however it offers an explicit `ack` functiont to
acknowledge receipt, or completion. This not only allows for partial
processing (i.e. like HTTP Accepted), but also supports returning a
value, which can be useful in systems that have asynchronous message
sysetems for some features, and synchronous message systems for other.

As an example, Slack's command, event, and interactions features are all
asynchronous, but their call feature is synchronous, and requires a
slightly different response from Slack apps. Delivery is the best
publishing method for that.