### PR TITLE
fix: fixes #7 Errors in subscriptions are swallowed by emit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,8 @@
     "extends": ["standard"],
     "rules": {
         "no-unused-expressions": "off",
-        "comma-dangle": ["error", "always-multiline"]
+        "comma-dangle": ["error", "always-multiline"],
+        "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
+        "no-console": "error"
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const { Topic } = require('@polyn/async-events')
 const logger = new Topic({ topic: 'logger' })
 
 // subscribe to 1 type of event
-logger.subscribe('error', (event, meta) => {
+logger.subscribe('info', (event, meta) => {
   // do something with the event, or metadata
 })
 
@@ -35,6 +35,23 @@ logger.subscribe(
   ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
   (event, meta) => console.log(`${meta.time}::${JSON.stringify(event)}`)
 )
+```
+
+### Subscribing to subscriber errors
+
+```JavaScript
+const { Topic } = require('@polyn/async-events')
+
+const emitter = new Topic({ topic: 'emitter' })
+
+emitter.subscribe('something', async (event, meta) => { throw new Error('BOOM!') })
+emitter.subscribe('error', (event, meta) => {
+  // do something with the event, or metadata
+  console.log(event, meta)
+})
+
+emitter.publish('something', 42)
+// emits an 'error' event because a subscriber threw
 ```
 
 #### Event Metadata
@@ -62,13 +79,13 @@ const logger = new Topic({ topic: 'logger' })
 
 // Subscribing to an event once can be accomplished by unsubscribing
 // from within the event handler
-logger.subscribe('error', (event, meta) => {
+logger.subscribe('info', (event, meta) => {
   logger.unsubscribe(meta.subscriptionId)
   console.log(event)
 })
 
 // Unsubscribing can also be accomplished outside of the event
-const { subscriptionId } = logger.subscribe('error', (event, meta) => {
+const { subscriptionId } = logger.subscribe('info', (event, meta) => {
   console.log(event)
 })
 
@@ -85,7 +102,7 @@ const { Topic } = require('@polyn/async-events')
 const logger = new Topic({ topic: 'logger' })
 
 // subscribe to 1 type of event
-logger.subscribe('error', (event, meta) => {
+logger.subscribe('info', (event, meta) => {
   // do something with the event, or metadata
 })
 
@@ -172,7 +189,7 @@ const { Topic } = require('@polyn/async-events')
 const logger = new Topic({ topic: 'logger' })
 
 // subscribe to 1 type of event
-logger.subscribe('error', (event, meta) => {
+logger.subscribe('info', (event, meta) => {
   // do something with the event, or metadata
 })
 
@@ -255,7 +272,7 @@ const { Topic } = require('@polyn/async-events')
 const logger = new Topic({ topic: 'logger', timeout: 3000 })
 
 // subscribe to 1 type of event
-logger.subscribe('error', (event, meta) => {
+logger.subscribe('info', (event, meta) => {
   // do something with the event, or metadata
 })
 

--- a/README.md
+++ b/README.md
@@ -37,20 +37,38 @@ logger.subscribe(
 )
 ```
 
-### Subscribing to subscriber errors
+### Subscribing to subscriber errors and reporting
+
+When creating a topic, you can set the reportVerbosity, as well as the event names that are used to emit fullfilment and rejection states. By default, this library will emit errors using an 'error' event. You can turn off 'error' emission by setting `reportVerbosity to 'none'. By default, this library does not emit fulfullment. You can turn fulfilment emission on by setting `reportVerbosity` to 'all'. The default event for fulfilment is `fulfilled`.
+
+The topic level verbosity can be overriden by passing a `reportVerbosity` value as part of the `meta` argument when emitting, publishing, or delivering to a topic (shown below).
+
+
 
 ```JavaScript
 const { Topic } = require('@polyn/async-events')
 
-const emitter = new Topic({ topic: 'emitter' })
+const emitter = new Topic({
+  topic: 'emitter',
+  reportVerbosity: 'errors', // all|errors|none; 'errors' is default
+  reportEventNames: {        // emample uses the default values
+    fulfilled: 'fulfilled',
+    rejected: 'error',
+  },
+})
 
+emitter.subscribe('something', async (event, meta) => { /*...*/ })
 emitter.subscribe('something', async (event, meta) => { throw new Error('BOOM!') })
+emitter.subscribe('fulfilled', (event, meta) => {
+  // do something with the event, or metadata
+  console.log(event, meta)
+})
 emitter.subscribe('error', (event, meta) => {
   // do something with the event, or metadata
   console.log(event, meta)
 })
 
-emitter.publish('something', 42)
+emitter.publish('something', 42, { reportVerbosity: 'all' })
 // emits an 'error' event because a subscriber threw
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,12 @@ export interface ITopicRepo {
 interface ITopicOptions {
   topic: string;
   repo?: ITopicRepo;               // default is in memory repo
+  timeout?: number;
+  reportVerbosity?: string;         // ^(all|errors|none)$;
+  reportEventNames?: {
+    emitted?: string;
+    error?: string;
+  }
 }
 
 export interface ITopic {

--- a/index.test.js
+++ b/index.test.js
@@ -991,7 +991,7 @@ module.exports = (test, dependencies) => {
           topic.subscribe('message', () => { throw new Error('Boom1') })
           topic.subscribe('message', () => { throw new Error('Boom2') })
           topic.subscribe('message', () => { throw new Error('Boom3') })
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.publish('message', 42, { reportVerbosity: 'all' })
 
@@ -1004,39 +1004,39 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when I publish and an asynchronous handler throws': {
         when: async () => {
           const events = []
           const topic = new Topic({ topic: String(random()) })
-          const fullfilled = (value) => new Promise((resolve) => {
+          const fulfilled = (value) => new Promise((resolve) => {
             setTimeout(() => resolve(value), 1)
           })
           const rejected = (message) => () => new Promise((resolve, reject) => {
             setTimeout(() => reject(new Error(message)), 1)
           })
 
-          topic.subscribe('message', fullfilled)
-          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fulfilled)
+          topic.subscribe('message', fulfilled)
           topic.subscribe('message', rejected('Boom1'))
           topic.subscribe('message', rejected('Boom2'))
           topic.subscribe('message', rejected('Boom3'))
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.publish('message', 42, { reportVerbosity: 'all' })
 
@@ -1049,20 +1049,20 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when I emit and a synchronous handler throws': {
@@ -1074,7 +1074,7 @@ module.exports = (test, dependencies) => {
           topic.subscribe('message', () => { throw new Error('Boom1') })
           topic.subscribe('message', () => { throw new Error('Boom2') })
           topic.subscribe('message', () => { throw new Error('Boom3') })
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.emit('message', 42, { reportVerbosity: 'all' })
 
@@ -1087,39 +1087,39 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when I emit and an asynchronous handler throws': {
         when: async () => {
           const events = []
           const topic = new Topic({ topic: String(random()) })
-          const fullfilled = (value) => new Promise((resolve) => {
+          const fulfilled = (value) => new Promise((resolve) => {
             setTimeout(() => resolve(value), 1)
           })
           const rejected = (message) => () => new Promise((resolve, reject) => {
             setTimeout(() => reject(new Error(message)), 1)
           })
 
-          topic.subscribe('message', fullfilled)
-          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fulfilled)
+          topic.subscribe('message', fulfilled)
           topic.subscribe('message', rejected('Boom1'))
           topic.subscribe('message', rejected('Boom2'))
           topic.subscribe('message', rejected('Boom3'))
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.emit('message', 42, { reportVerbosity: 'all' })
 
@@ -1132,20 +1132,20 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when I deliver and a synchronous handler throws': {
@@ -1157,7 +1157,7 @@ module.exports = (test, dependencies) => {
           topic.subscribe('message', () => { throw new Error('Boom1') })
           topic.subscribe('message', () => { throw new Error('Boom2') })
           topic.subscribe('message', () => { throw new Error('Boom3') })
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.deliver('message', 42, { reportVerbosity: 'all' })
 
@@ -1170,27 +1170,27 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when I deliver and an asynchronous handler throws': {
         when: async () => {
           const events = []
           const topic = new Topic({ topic: String(random()) })
-          const fullfilled = (value, meta, ack) => new Promise((resolve) => {
+          const fulfilled = (value, meta, ack) => new Promise((resolve) => {
             setTimeout(() => {
               ack(null, value)
               resolve(value)
@@ -1200,12 +1200,12 @@ module.exports = (test, dependencies) => {
             setTimeout(() => reject(new Error(message)), 1)
           })
 
-          topic.subscribe('message', fullfilled)
-          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fulfilled)
+          topic.subscribe('message', fulfilled)
           topic.subscribe('message', rejected('Boom1'))
           topic.subscribe('message', rejected('Boom2'))
           topic.subscribe('message', rejected('Boom3'))
-          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('fulfilled', (value, meta) => events.push({ value, meta }))
           topic.subscribe('error', (err, meta) => events.push({ err, meta }))
           await topic.deliver('message', 42, { reportVerbosity: 'all' })
 
@@ -1218,20 +1218,20 @@ module.exports = (test, dependencies) => {
         'it should emit errors for each failed emission': (expect) => (err, actual) => {
           expect(err).to.be.null
 
-          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const fulfilled = actual.events.filter((event) => event.meta.event === 'fulfilled')
           const rejected = actual.events.filter((event) => event.meta.event === 'error')
           const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
           const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
           const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
 
           expect(actual.events.length).to.equal(5)
-          expect(fullfilled.length).to.equal(2)
+          expect(fulfilled.length).to.equal(2)
           expect(rejected.length).to.equal(3)
           expect(boom1.length).to.equal(1)
           expect(boom2.length).to.equal(1)
           expect(boom3.length).to.equal(1)
 
-          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+          fulfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when a subscriber doesn\'t acknowledge a delivery': {

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,7 @@
 module.exports = (test, dependencies) => {
   'use strict'
 
-  const { Topic, id, WildcardEmitter } = dependencies
+  const { allSettled, Topic, id, WildcardEmitter } = dependencies
   const random = id.makeId
 
   return test('given @polyn/async-events', {
@@ -841,8 +841,37 @@ module.exports = (test, dependencies) => {
           },
         },
       },
+      'when makeWildcards is called with a non-string event': {
+        when: (emitter) => emitter.makeWildcards({}),
+        'it should return the default wildcard': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual).to.deep.equal(['%'])
+        },
+      },
+      'when makeWildcards is called with a string that has no delimiter': {
+        when: (emitter) => emitter.makeWildcards('delimiter'),
+        'it should return the default wildcard': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual).to.deep.equal(['%'])
+        },
+      }
     },
     'failure modes': {
+      'when something other than a promise is executed by allSettled': {
+        when: async () => allSettled([() => {}]),
+        'it should report that the promise was rejected': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual[0].status).to.equal('rejected')
+          expect(actual[0].reason.message).to.equal('promise.then is not a function')
+        }
+      },
+      'when id.makeTemplate is called with a length less than 1': {
+        when: () => id.makeTemplate(0),
+        'it should throw': (expect) => (err) => {
+          expect(err).to.not.equal(null)
+          expect(err.message).to.equal('Invalid id length: expected length to be a number greater than 0')
+        }
+      },
       'when I subscribe with a null event name': {
         when: async () => {
           const topic = new Topic({ topic: String(random()) })
@@ -951,6 +980,258 @@ module.exports = (test, dependencies) => {
         'it should throw': (expect) => (err) => {
           expect(err).to.not.be.null
           expect(err.message.includes('Invalid PublishOptions')).to.equal(true)
+        },
+      },
+      'when I publish and a synchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          topic.subscribe('message', (value) => { return value })
+          topic.subscribe('message', (value) => { return value })
+          topic.subscribe('message', () => { throw new Error('Boom1') })
+          topic.subscribe('message', () => { throw new Error('Boom2') })
+          topic.subscribe('message', () => { throw new Error('Boom3') })
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.publish('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+        },
+      },
+      'when I publish and an asynchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          const fullfilled = (value) => new Promise((resolve) => {
+            setTimeout(() => resolve(value), 1)
+          })
+          const rejected = (message) => () => new Promise((resolve, reject) => {
+            setTimeout(() => reject(new Error(message)), 1)
+          })
+
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', rejected('Boom1'))
+          topic.subscribe('message', rejected('Boom2'))
+          topic.subscribe('message', rejected('Boom3'))
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.publish('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+        },
+      },
+      'when I emit and a synchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          topic.subscribe('message', (value) => { return value })
+          topic.subscribe('message', (value) => { return value })
+          topic.subscribe('message', () => { throw new Error('Boom1') })
+          topic.subscribe('message', () => { throw new Error('Boom2') })
+          topic.subscribe('message', () => { throw new Error('Boom3') })
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.emit('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+        },
+      },
+      'when I emit and an asynchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          const fullfilled = (value) => new Promise((resolve) => {
+            setTimeout(() => resolve(value), 1)
+          })
+          const rejected = (message) => () => new Promise((resolve, reject) => {
+            setTimeout(() => reject(new Error(message)), 1)
+          })
+
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', rejected('Boom1'))
+          topic.subscribe('message', rejected('Boom2'))
+          topic.subscribe('message', rejected('Boom3'))
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.emit('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+        },
+      },
+      'when I deliver and a synchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          topic.subscribe('message', (value, meta, ack) => { ack(null, value) })
+          topic.subscribe('message', (value, meta, ack) => { ack(null, value) })
+          topic.subscribe('message', () => { throw new Error('Boom1') })
+          topic.subscribe('message', () => { throw new Error('Boom2') })
+          topic.subscribe('message', () => { throw new Error('Boom3') })
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.deliver('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
+        },
+      },
+      'when I deliver and an asynchronous handler throws': {
+        when: async () => {
+          const events = []
+          const topic = new Topic({ topic: String(random()) })
+          const fullfilled = (value, meta, ack) => new Promise((resolve) => {
+            setTimeout(() => {
+              ack(null, value)
+              resolve(value)
+            }, 1)
+          })
+          const rejected = (message) => () => new Promise((resolve, reject) => {
+            setTimeout(() => reject(new Error(message)), 1)
+          })
+
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', fullfilled)
+          topic.subscribe('message', rejected('Boom1'))
+          topic.subscribe('message', rejected('Boom2'))
+          topic.subscribe('message', rejected('Boom3'))
+          topic.subscribe('_emitted', (value, meta) => events.push({ value, meta }))
+          topic.subscribe('error', (err, meta) => events.push({ err, meta }))
+          await topic.deliver('message', 42, { reportVerbosity: 'all' })
+
+          while (events.length < 5) {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+          }
+
+          return { events }
+        },
+        'it should emit errors for each failed emission': (expect) => (err, actual) => {
+          expect(err).to.be.null
+
+          const fullfilled = actual.events.filter((event) => event.meta.event === '_emitted')
+          const rejected = actual.events.filter((event) => event.meta.event === 'error')
+          const boom1 = rejected.filter((event) => event.err.message === 'Boom1')
+          const boom2 = rejected.filter((event) => event.err.message === 'Boom2')
+          const boom3 = rejected.filter((event) => event.err.message === 'Boom3')
+
+          expect(actual.events.length).to.equal(5)
+          expect(fullfilled.length).to.equal(2)
+          expect(rejected.length).to.equal(3)
+          expect(boom1.length).to.equal(1)
+          expect(boom2.length).to.equal(1)
+          expect(boom3.length).to.equal(1)
+
+          fullfilled.forEach((event) => expect(event.value).to.equal(42))
         },
       },
       'when a subscriber doesn\'t acknowledge a delivery': {

--- a/src/Topic.js
+++ b/src/Topic.js
@@ -51,7 +51,7 @@ module.exports = {
     function Topic (topicOptions) {
       const options = new TopicOptions(topicOptions)
 
-      const repo = options.repo ?? TopicMemoryRepo(options.topic)
+      const repo = options.repo || TopicMemoryRepo(options.topic)
       const { publish, emit, deliver } = Publisher(options, repo)
 
       return {

--- a/src/Topic.js
+++ b/src/Topic.js
@@ -4,7 +4,7 @@ module.exports = {
   factory: (polynBp, polynIm, TopicMemoryRepo, Publisher) => {
     'use strict'
 
-    const { optional, registerBlueprint, required } = polynBp
+    const { optional, registerBlueprint } = polynBp
     const { immutable } = polynIm
 
     /**

--- a/src/all-settled.js
+++ b/src/all-settled.js
@@ -4,6 +4,20 @@ module.exports = {
   factory: () => {
     'use strict'
 
+    /**
+     * The outcome of a Promise that was executed with `allSettled`
+     * @typedef {Object} AllSettledResolution
+     * @property {^(fullfilled|rejected)$} status - whether the promise called "resolve" or "reject"
+     * @property {any?} value - the value that was passed to "resolve", if any
+     * @property {Error} reason - the error that was passed to "reject", if any
+     */
+
+    /**
+     * Executes an array of promises concurrently, and returns the outcomes
+     * of each promise
+     * @param {AsyncFunction<any?>[]} promises - the array of promises to execute
+     * @returns {AllSettledResolution[]} - an array of outcomes from executed promises
+     */
     function allSettled (promises) {
       return Promise.all(promises.map((promise) => {
         return new Promise((resolve) => {

--- a/src/all-settled.js
+++ b/src/all-settled.js
@@ -7,7 +7,7 @@ module.exports = {
     /**
      * The outcome of a Promise that was executed with `allSettled`
      * @typedef {Object} AllSettledResolution
-     * @property {^(fullfilled|rejected)$} status - whether the promise called "resolve" or "reject"
+     * @property {^(fulfilled|rejected)$} status - whether the promise called "resolve" or "reject"
      * @property {any?} value - the value that was passed to "resolve", if any
      * @property {Error} reason - the error that was passed to "reject", if any
      */

--- a/src/id.js
+++ b/src/id.js
@@ -49,6 +49,6 @@ module.exports = {
      */
     const parseComposite = (id) => id.split(ID_DELIM)
 
-    return { makeId, makeComposite, parseComposite }
+    return { makeId, makeComposite, parseComposite, makeTemplate }
   },
 }

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,12 +1,13 @@
 module.exports = {
   name: 'publish',
   dependencies: ['@polyn/blueprint', '@polyn/immutable', 'id', 'allSettled'],
-  factory: (polynBp, polynIm, id, allSettled) => (topic, repo, defaultTimeout) => {
+  factory: (polynBp, polynIm, id, allSettled) => (topicOptions, repo) => {
     'use strict'
 
     const { is, optional, required } = polynBp
     const { immutable } = polynIm
     const { makeComposite } = id
+    const { topic } = topicOptions
 
     /**
      * The outcome of settling all subscriptions for an event that was published,
@@ -39,9 +40,9 @@ module.exports = {
       body: 'any?',
       meta: optional('any').withDefault({}),
       reportVerbosity: required(/^(all|errors|none)$/).from(({ output }) =>
-        output.meta.reportVerbosity || 'errors'
+        output.meta.reportVerbosity || topicOptions.reportVerbosity
       ),
-      timeout: optional('number').withDefault(defaultTimeout),
+      timeout: optional('number').withDefault(topicOptions.timeout),
     })
 
     /**
@@ -156,9 +157,9 @@ module.exports = {
 
       results.forEach((result) => {
         if (reportVerbosity === 'all' && result.status === 'fulfilled') {
-          emit('_emitted', result.value, { ...meta, ...{ reportVerbosity: 'none' }})
+          emit(topicOptions.reportEventNames.fulfilled, result.value, { ...meta, ...{ reportVerbosity: 'none' }})
         } else if (result.status === 'rejected') {
-          emit('error', result.reason, { ...meta, ... { reportVerbosity: 'none' }})
+          emit(topicOptions.reportEventNames.rejected, result.reason, { ...meta, ... { reportVerbosity: 'none' }})
         }
       })
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -35,12 +35,12 @@ module.exports = {
      */
     const PublishOptions = immutable('PublishOptions', {
       name: required('string').from(
-        ({ value }) => typeof value === 'string' && value.toLowerCase().trim()
+        ({ value }) => typeof value === 'string' && value.toLowerCase().trim(),
       ),
       body: 'any?',
       meta: optional('any').withDefault({}),
       reportVerbosity: required(/^(all|errors|none)$/).from(({ output }) =>
-        output.meta.reportVerbosity || topicOptions.reportVerbosity
+        output.meta.reportVerbosity || topicOptions.reportVerbosity // eslint-disable-line comma-dangle
       ),
       timeout: optional('number').withDefault(topicOptions.timeout),
     })
@@ -132,7 +132,7 @@ module.exports = {
               } catch (e) {
                 ack(e)
               }
-            })
+            }),
           )
 
           return { subscriptions, makeMeta }
@@ -157,9 +157,9 @@ module.exports = {
 
       results.forEach((result) => {
         if (reportVerbosity === 'all' && result.status === 'fulfilled') {
-          emit(topicOptions.reportEventNames.fulfilled, result.value, { ...meta, ...{ reportVerbosity: 'none' }})
+          emit(topicOptions.reportEventNames.fulfilled, result.value, { ...meta, ...{ reportVerbosity: 'none' } })
         } else if (result.status === 'rejected') {
-          emit(topicOptions.reportEventNames.rejected, result.reason, { ...meta, ... { reportVerbosity: 'none' }})
+          emit(topicOptions.reportEventNames.rejected, result.reason, { ...meta, ...{ reportVerbosity: 'none' } })
         }
       })
 
@@ -187,7 +187,7 @@ module.exports = {
               meta: makeMeta(),
               results,
             }
-          })
+          }) // eslint-disable-line comma-dangle
       ) // /shipToSubscribers.then
     } // /publish
 
@@ -234,7 +234,7 @@ module.exports = {
                 meta: makeMeta(),
                 results,
               }
-            })
+            }) // eslint-disable-line comma-dangle
         ) // /shipToSubscribers.withAckRequests.then
     } // /deliver
 

--- a/src/topic-memory-repo.js
+++ b/src/topic-memory-repo.js
@@ -63,8 +63,8 @@ module.exports = {
     /**
      * Initializes the topic's event, if it doesn't exist, and adds a subscription to
      * that event
-     * @param name {string|string[]} - the name(s) of the event(s)
-     * @param receiver {function} - the handler/callback that will be called when that event is published
+     * @param {string|string[]} name - the name(s) of the event(s)
+     * @param {function} receiver - the handler/callback that will be called when that event is published
      * @returns {Promise<string|string[]>} - an id per name, which can be used to unsubscribe
      */
     const subscribe = (names, receiver) => new Promise((resolve, reject) => {
@@ -81,7 +81,7 @@ module.exports = {
     /**
      * Removes a subscription from a topic event, by id (the string returned by the
      * `subscribe` function)
-     * @param id {string} - the id of the subscription to remove
+     * @param {string} id - the id of the subscription to remove
      * @returns {Promise<boolean>} - whether or not the subscriber was removed
      */
     const unsubscribe = (id) => new Promise((resolve, reject) => {
@@ -103,7 +103,7 @@ module.exports = {
 
     /**
      * Gets subscriptions by topic name
-     * @param name {string} - the name of the topic to get subscriptions for
+     * @param {string} name - the name of the topic to get subscriptions for
      * @returns {Promise<{id: string, receiver: function}[]>} - the receivers that are registered for the topic
      */
     const getSubscriptions = (name) => new Promise((resolve, reject) => {
@@ -118,7 +118,7 @@ module.exports = {
 
     /**
      * Checks whether a topic has any subscriptions
-     * @param name {string} - the name of the topic to check
+     * @param {string} name - the name of the topic to check
      * @returns {Promise<boolean>} - whether or not the topic has any subscriptions
      */
     const hasSubscriptions = (name) => new Promise((resolve, reject) => {

--- a/test.js
+++ b/test.js
@@ -1,11 +1,12 @@
 const { expect } = require('chai')
 const supposed = require('supposed')
+const { allSettled } = require('./src/all-settled').factory()
 const { Topic, WildcardEmitter } = require('./index')
 const id = require('./src/id').factory()
 
 module.exports = supposed.Suite({
   name: 'polyn-async-events',
   assertionLibrary: expect,
-  inject: { Topic, id, WildcardEmitter },
+  inject: { allSettled, Topic, id, WildcardEmitter },
 }).runner()
   .run()


### PR DESCRIPTION
- Adds reporting for errors and fulfillment
- Improves handling of errors states
- Improves documentation and jsdoc
- Improves test coverage

Before:

```
❯ node try.js
received body
emit result: {
  count: 1,
  meta: {
    id: 'myTopic::message::v9wmlyfh',
    time: 1652702764709,
    topic: 'myTopic',
    event: 'message'
  }
}
```

After

```
❯ node try.js
received body
emit result: {
  count: 1,
  meta: {
    id: 'myTopic::message::e83vu659',
    time: 1652702790384,
    topic: 'myTopic',
    event: 'message'
  }
}
Error: subscriber error
    at Object.receiver (/Users/name/repos/polyn-async-events/try.js:6:9)
    at /Users/name/repos/polyn-async-events/src/publish.js:88:43
    at Array.map (<anonymous>)
    at /Users/name/repos/polyn-async-events/src/publish.js:86:48 {
  id: 'myTopic::error::m79u7652',
  time: 1652702790391,
  topic: 'myTopic',
  event: 'error',
  reportVerbosity: 'none',
  subscriptionId: 'myTopic::error::48q5p22c'
}
```
